### PR TITLE
fixed api endpoints

### DIFF
--- a/backend/app/api/correlationexplorer.py
+++ b/backend/app/api/correlationexplorer.py
@@ -26,7 +26,7 @@ PUBMED_EFETCH_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
 
 correlation_api = Blueprint('correlation_api', __name__, url_prefix='/api')
 
-@correlation_api.route('/api/top_correlations', methods=['GET'])
+@correlation_api.route('top-correlations', methods=['GET'])
 def top_correlations():
     corr_type = request.args.get('type', 'gene_gene')
     preset_feature = request.args.get('feature', None) 
@@ -153,7 +153,7 @@ def summarize_with_openai(prompt):
     return response.choices[0].message.content
 
 
-@correlation_api.route('/api/explore-correlation', methods=['POST'])
+@correlation_api.route('/explore-correlation', methods=['POST'])
 def explore_correlation():
     data = request.json
     feature_1 = data.get('feature_1')
@@ -189,12 +189,12 @@ def explore_correlation():
         "citations": citation_list
     })
 
-@correlation_api.route('/api/list-genes', methods=['GET'])
+@correlation_api.route('/list-genes', methods=['GET'])
 def list_genes():
     expr_df = load_expression("filtered")
     return jsonify(sorted(expr_df.columns.tolist()))
 
-@correlation_api.route('/api/list-clinical', methods=['GET'])
+@correlation_api.route('/list-clinical', methods=['GET'])
 def list_clinical():
     clinical_onehot = load_clinical('onehot')
     # Optionally filter out predictions or non-user-facing columns

--- a/backend/app/api/differentialexpression.py
+++ b/backend/app/api/differentialexpression.py
@@ -8,7 +8,7 @@ from statsmodels.stats.multitest import multipletests
 dea_api = Blueprint('dea_api', __name__, url_prefix='/api')
 
 
-@dea_api.route('/api/dea', methods=['POST'])
+@dea_api.route('/dea', methods=['POST'])
 def api_dea():
     data = request.json
     clinical_variable = data['clinical_variable']
@@ -79,7 +79,7 @@ def api_dea():
     })
 
 
-@dea_api.route('/api/clinical-variables', methods=['GET'])
+@dea_api.route('/clinical-variables', methods=['GET'])
 def api_clinical_variables():
     clinical_df = load_clinical('llm')
     clinical_vars = []

--- a/frontend/src/pages/CorrelationExplorer.js
+++ b/frontend/src/pages/CorrelationExplorer.js
@@ -46,7 +46,7 @@ const CorrelationExplorer = () => {
 
     // Fetch correlations based on conditions
     if (!presetGene && !presetClinical) {
-      fetch(`${BACKEND_URL} /api/top_correlations?type=${corrType}`)
+      fetch(`${BACKEND_URL}/api/top-correlations?type=${corrType}`)
         .then(res => res.json())
         .then(setCorrelations)
         .catch(err => setError('Could not load correlations: ' + err.message))
@@ -140,7 +140,7 @@ const CorrelationExplorer = () => {
           onClick={() => {
             setLoading(true);
             const filterValue = presetGene || presetClinical;
-            fetch(`/api/top_correlations?type=${corrType}&feature=${encodeURIComponent(filterValue)}`)
+            fetch(`${BACKEND_URL}/api/top-correlations?type=${corrType}&feature=${encodeURIComponent(filterValue)}`)
               .then(res => res.json())
               .then(setCorrelations)
               .catch(err => setError('Could not load correlations: ' + err.message))


### PR DESCRIPTION
This pull request standardizes API endpoint routes by removing redundant `/api` prefixes and updates the corresponding frontend code to reflect these changes. The goal is to simplify and streamline the API structure for better readability and maintainability.

### Backend API Route Updates:

* [`backend/app/api/correlationexplorer.py`](diffhunk://#diff-f782e290d0aac4398126f77f34ca5052f57ab2f293d155161e49a9dab6c7d5b4L29-R29): Updated API routes to remove the `/api` prefix for endpoints such as `top-correlations`, `explore-correlation`, `list-genes`, and `list-clinical`. [[1]](diffhunk://#diff-f782e290d0aac4398126f77f34ca5052f57ab2f293d155161e49a9dab6c7d5b4L29-R29) [[2]](diffhunk://#diff-f782e290d0aac4398126f77f34ca5052f57ab2f293d155161e49a9dab6c7d5b4L156-R156) [[3]](diffhunk://#diff-f782e290d0aac4398126f77f34ca5052f57ab2f293d155161e49a9dab6c7d5b4L192-R197)
* [`backend/app/api/differentialexpression.py`](diffhunk://#diff-99add7baa140a0515589ee235dc5cddb0e836745c20a2738177bc6fb4c7f3088L11-R11): Simplified API routes by removing the `/api` prefix for `dea` and `clinical-variables` endpoints. [[1]](diffhunk://#diff-99add7baa140a0515589ee235dc5cddb0e836745c20a2738177bc6fb4c7f3088L11-R11) [[2]](diffhunk://#diff-99add7baa140a0515589ee235dc5cddb0e836745c20a2738177bc6fb4c7f3088L82-R82)

### Frontend Adjustments:

* [`frontend/src/pages/CorrelationExplorer.js`](diffhunk://#diff-55c2d7947ea04480d39be9497ce33cb00e31cf280de894f0928ca74fd7682d58L49-R49): Updated fetch calls to match the new backend API routes for `top-correlations`. [[1]](diffhunk://#diff-55c2d7947ea04480d39be9497ce33cb00e31cf280de894f0928ca74fd7682d58L49-R49) [[2]](diffhunk://#diff-55c2d7947ea04480d39be9497ce33cb00e31cf280de894f0928ca74fd7682d58L143-R143)